### PR TITLE
KDB4 and Rockylinux 9 hardening patch

### DIFF
--- a/configure
+++ b/configure
@@ -146,7 +146,7 @@ else
     fi
 fi
 case $KXVER in
-    2|3) ;;
+    2|3|4) ;;
     *) echo "unknown q version." >&2; exit 1 ;;
 esac
 

--- a/src/conmin.h
+++ b/src/conmin.h
@@ -7,7 +7,7 @@ F* take_param(K x, I* n, S* err);
 F* make_param(K x, F* param, K* r);
 
 
-struct call_info {
+extern struct call_info {
     int arg; // 0 = make_param(start), 1/-1 = base+arg*scalar
     F base;
     K start;

--- a/src/util.h
+++ b/src/util.h
@@ -6,7 +6,7 @@
 
 #include <k.h>
 
-#if KXVER == 3
+#if KXVER >= 3
 #define _l  j
 #define  L  J
 #define KL KJ


### PR DESCRIPTION
/usr/bin/ld: conmax.o:(.bss+0x0): multiple definition of `call'; conmin.o:(.bss+0x40): first defined here
/usr/bin/ld: nlopt.o:(.bss+0x0): multiple definition of `call'; conmin.o:(.bss+0x40): first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [../mk/src.mk:43: qml.so] Error 1
make[1]: Leaving directory '/home/vgrechin/git/hub/qml/src'
make: *** [Makefile:7: src_build] Error 2